### PR TITLE
[Fix-131] show user friendly error on mentor page when user is not auth

### DIFF
--- a/src/pages/MentorUserProfilePage/ui/MentorUserProfilePage.tsx
+++ b/src/pages/MentorUserProfilePage/ui/MentorUserProfilePage.tsx
@@ -51,7 +51,7 @@ export default function MentorUserProfilePage() {
   if (!mentor) {
     return <div className="flex flex-col sm:flex-row items-center justify-center h-screen text-2xl  sm:text-xl md:text-2xl font-montserrat font-medium gap-2 text-center px-4">
       <p className="mb-2 sm:mb-0">Please login to view this page.</p>
-     <Link to={'/login'} className="underline hover:text-pink-300 decoration-gray-400">Apply here to login</Link>
+     <Link to={'/login'} className="underline hover:text-pink-600 decoration-gray-400">Apply here to login</Link>
      </div>;
 
   }


### PR DESCRIPTION
<img width="1408" height="815" alt="image" src="https://github.com/user-attachments/assets/ac724133-eabe-41e5-8920-b67321af4a3e" />
<img width="419" height="778" alt="image" src="https://github.com/user-attachments/assets/545d2e24-1b3c-45cf-bd5e-7338b8e58215" />
